### PR TITLE
fix p2p plotting

### DIFF
--- a/src/signal-server.cc
+++ b/src/signal-server.cc
@@ -1800,9 +1800,8 @@ int handle_args(int argc, char *argv[], output &out)
         strncpy(out.tx_site[0].name, "Tx", 3);
         strncpy(out.tx_site[1].name, "Rx", 3);
         PlotPath(&out, out.tx_site[0], out.tx_site[1], 1, &lr);
-        /* PathReport(out.tx_site[0], out.tx_site[1], NULL, 0, propmodel, pmenv, rxGain, &out, lr); */
         // Order flipped for benefit of graph. Makes no difference to data.
-        SeriesData(out.tx_site[1], out.tx_site[0], 1, normalise, &out, lr);
+        SeriesData(out.tx_site[1], out.tx_site[0], 1, 1, &out, lr);
     }
     fflush(stderr);
 


### PR DESCRIPTION
This PR does two things:

1. turns on normalization by default
2. fixes last point in fresnel zone data

Before:
![Screen Shot 2023-07-31 at 4 24 28 PM](https://github.com/JayKickliter/Signal-Server/assets/2551201/e5b03ad2-b13c-44a0-b8dd-939be5ef1ed4)

After:
![Screen Shot 2023-07-31 at 4 24 35 PM](https://github.com/JayKickliter/Signal-Server/assets/2551201/7e7ddcbe-0e63-4d14-9945-11aaa4457a3d)

